### PR TITLE
Fixed README to use correct name for gamma function

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Get exponentionally distributed number with lambda 1
 **Number `poisson( mean )`**
 Get poisson distributed number, the mean defaulting to 1
 
-**Number `gaussian( a )`**
+**Number `gamma( a )`**
 Get gamma distributed number, using uniform, normal and exp with the Marsaglia-Tsang method
 
 


### PR DESCRIPTION
README said it was called `gaussian( a )` but in the code it is defined as `gamma( a )`.